### PR TITLE
Perf: Optimize setTimeout and code

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -6,37 +6,32 @@ export default function Home() {
   const previewRef = useRef(null);
   const descRef = useRef(null);
 
-  function strike(text) {
+  const strike = (text) => {
     return text
       .split("")
       .map((char) => char + "\u0336")
       .join("");
-  }
+  };
 
   const input = (event) => {
     const value = event.target.value;
     descRef.current.innerText =
       "Striked text will automatically be copied to clipboard.";
-    if (value === "") {
-      previewRef.current.innerText = "";
-    } else {
-      previewRef.current.innerText = strike(value);
-    }
+    previewRef.current.innerText = value ? strike(value) : "";
   };
 
   let timeout = null;
-  let cotime = null;
-  function copyText() {
-    const value = previewRef.current.innerHTML;
+  const copyText = () => {
     clearTimeout(timeout);
-    timeout = setTimeout(function () {
-      if(value) navigator.clipboard.writeText(previewRef.current.innerHTML);
-    }, 1000);
-    clearTimeout(cotime);
-    cotime = setTimeout(function () {
-      if(value) descRef.current.innerHTML = `<span class=${styles.span}>Text Copied!</span>`;
-    }, 1000);
-  }
+    const value = previewRef.current.innerHTML;
+
+    if (value) {
+      timeout = setTimeout(() => {
+        navigator.clipboard.writeText(previewRef.current.innerHTML);
+        descRef.current.innerHTML = `<span class=${styles.span}>Text Copied!</span>`;
+      }, 1000);
+    }
+  };
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
1. Removed the second `setTimeout` (cotime) and improve the performance, doing both things (copy text and showing up) in a single one

![imagen](https://user-images.githubusercontent.com/39889256/135769981-1509788f-2ca6-457a-85d9-f8a3ea5e7376.png)

2. Used the new JS sintax and make a code better readable
![imagen](https://user-images.githubusercontent.com/39889256/135770005-9e2864f2-6a57-41e3-806d-67311806e836.png)
